### PR TITLE
Fixed android keyboard bug on load

### DIFF
--- a/src/tonegod/gui/style/def/style_map.gui.xml
+++ b/src/tonegod/gui/style/def/style_map.gui.xml
@@ -18,4 +18,5 @@
 	<style control="Indicator" path="tonegod/gui/style/def/Common/Extras/Indicator.gui.xml" />
 	<style control="ColorWheel" path="tonegod/gui/style/def/Common/Extras/ColorWheel.gui.xml" />
 	<style control="Table" path="tonegod/gui/style/def/Table/Table.gui.xml" />
+	<style control="Keyboard" path="tonegod/gui/style/atlasdef/Keyboard/Keyboard.gui.xml" />
 </root>


### PR DESCRIPTION
The appropriate style definition for the Keyboard was missing. This caused the library to crash whenever it tried to load the keyboard with a NPE.